### PR TITLE
Read weather def list via field offset

### DIFF
--- a/WeatherManager.cs
+++ b/WeatherManager.cs
@@ -3,6 +3,7 @@ using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.InteropTypes;
 using MelonLoader;
 using UnityEngine;
+using System.Runtime.InteropServices;
 
 public static class WeatherManager
 {
@@ -26,7 +27,7 @@ public static class WeatherManager
                 return;
             }
 
-            IntPtr listPtr = IL2CPP.il2cpp_field_get_value_object(field, obj.Pointer);
+            IntPtr listPtr = Marshal.ReadIntPtr(obj.Pointer, (int)IL2CPP.il2cpp_field_get_offset(field));
             if (listPtr == IntPtr.Zero)
             {
                 MelonLogger.Msg("[Weather] weatherDefList is null.");


### PR DESCRIPTION
## Summary
- use field offset to grab `_weatherDefList`
- cast field offset to `int` when reading `_weatherDefList` pointer

## Testing
- `dotnet build 'Debug Tools.csproj'` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*
- `FrameworkPathOverride=/usr/lib/mono/4.7.2-api dotnet build 'Debug Tools.csproj'` *(fails: type 'Object' defined in assembly 'System.Runtime' not referenced)*
- `xbuild 'Debug Tools.csproj'` *(fails: Debugging Tools.cs compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4de6ddcfc83208be33c9c1a4a11a6