### PR TITLE
Fix WeatherManager field offset cast

### DIFF
--- a/WeatherManager.cs
+++ b/WeatherManager.cs
@@ -27,7 +27,7 @@ public static class WeatherManager
                 return;
             }
 
-            IntPtr listPtr = Marshal.ReadIntPtr(obj.Pointer, IL2CPP.il2cpp_field_get_offset(field));
+            IntPtr listPtr = Marshal.ReadIntPtr(obj.Pointer, (int)IL2CPP.il2cpp_field_get_offset(field));
             if (listPtr == IntPtr.Zero)
             {
                 MelonLogger.Msg("[Weather] weatherDefList is null.");


### PR DESCRIPTION
## Summary
- cast uint field offset to int when reading weatherDefList pointer

## Testing
- `xbuild 'Debug Tools.csproj'` *(fails: Debugging Tools.cs compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e4df4a4c83209e778e456cbd37d4